### PR TITLE
Fix code example in locking-api-versions.md

### DIFF
--- a/locking-api-versions.md
+++ b/locking-api-versions.md
@@ -14,8 +14,8 @@ You can globally configure a set of service API versions by specifying the `apiV
 
 ```
 AWS.config.apiVersions = {
-dynamodb: '2011-12-05',
-ec2: '2013-02-01',
-redshift: 'latest'Best Practices for Managing AWS Access Keys
+    dynamodb: '2011-12-05',
+    ec2: '2013-02-01',
+    redshift: 'latest'
 };
 ```


### PR DESCRIPTION
- Delete text "Best Practices for Managing AWS Access Keys" that was accidently added to the code example.
- Correctly indent code example.