### PR TITLE
Broken link to slotsassets.zip

### DIFF
--- a/using-lambda-browser-script.md
+++ b/using-lambda-browser-script.md
@@ -54,7 +54,7 @@ Next, update the browser script to include the Amazon Cognito identity pool ID c
 
 **To prepare the browser script in the webpage**
 
-1. Open the `slotsassets.zip` archive file that you downloaded from the [code example archive on GitHub](https://github.com/aws-doc-sdk-examples/javascript/example_code/lambda/tutorial/slotassets.zip )\.
+1. Open the `slotsassets.zip` archive file that you downloaded from the [code example archive on GitHub](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/javascript/example_code/lambda/tutorial/slotassets.zip)\.
 
 1. Open `index.html` in a text editor\.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Link to the static web app assets in the docs for the Slots Javascript/Lambda example is broken.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
