### PR TITLE
docs: add a new subpage for reusing TCP connections in Node.js

### DIFF
--- a/doc_source/node-js-considerations.md
+++ b/doc_source/node-js-considerations.md
@@ -38,4 +38,5 @@ One example of an npm package you can use with the AWS SDK for JavaScript is `br
 + [Using NPM Packages](#node-npm-packages)
 + [Configuring maxSockets in Node\.js](node-configuring-maxsockets.md)
 + [Configuring Proxies for Node\.js](node-configuring-proxies.md)
++ [Reusing Connections with Keep-Alive](node-reusing-connections.md)
 + [Registering Certificate Bundles in Node\.js](node-registering-certs.md)

--- a/doc_source/node-reusing-connections.md
+++ b/doc_source/node-reusing-connections.md
@@ -1,0 +1,47 @@
+# Reusing connections with keep-alive in Node\.js<a name="node-reusing-connections"></a>
+
+By default, Node\.js default HTTP/HTTPS agent creates a new TCP connection for every new request\. By not reusing already created connections, we incur the cost of establishing new ones, which includes 3-way or 7-way handshake depending on whether this is an HTTP or HTTPS transaction\. We are also not going to leverage the actual throughput established by the TCP protocol’s [flow and congestion controls](https://en.wikipedia.org/wiki/Additive_increase/multiplicative_decrease)\.
+
+For short-lived operations completing within a single-digit ms (like DynamoDB queries) the latency overhead of setting up a TCP connection might be greater than the operation itself\. Additionally, DynamoDB encryption at rest is integrated with [AWS KMS](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/encryption.howitworks.html) and you may experience latencies from the database having to re-establish new AWS KMS cache entries for each operation ([read more](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/encryption.howitworks.html))\.
+
+The easiest way to configure `aws-sdk-js` to reuse TCP connections is to set the `AWS_NODEJS_CONNECTION_REUSE_ENABLED` environment variable to `1`\. This feature was added in the [2.436.0](https://github.com/aws/aws-sdk-js/blob/master/CHANGELOG.md#24630) release\.
+
+Alternatively, an HTTP or HTTPS agent can be supplied with `keepAlive` set to `true`\.
+
+Example of setting it globally:
+
+```js
+const AWS = require('aws-sdk');
+
+// http or https as per your use case
+const http = require('http');
+const agent = new http.Agent({
+  keepAlive: true
+});
+
+AWS.config.update({
+  httpOptions: {
+    agent
+  }
+});
+```
+
+Example of setting `keepAlive` on a per-client basis:
+
+```js
+const AWS = require('aws-sdk')
+
+// http or https as per your use case
+const https = require('https');
+const agent = new https.Agent({
+  keepAlive: true
+});
+
+const dynamodb = new AWS.DynamoDB({
+  httpOptions: {
+    agent
+  }
+});
+```
+
+If the `keepAlive` option is enabled, you can also set the initial delay for TCP Keep-Alive packets with `keepAliveMsecs`, which by default is 1000ms ([refer to Node\.js official docs for more details](https://nodejs.org/api/http.html)).


### PR DESCRIPTION
*Issue #, if available:*
Multiple issues logged in `aws-sdk-js` repository from users discussing the default `keepAlive` behaviour:
- https://github.com/aws/aws-sdk-js/issues/146
- https://github.com/aws/aws-sdk-js/issues/671

*Description of changes:*
I would like to contribute a new page to the "Node.JS considerations" section of the documentation to inform the `aws-sdk-js` users of the importance of reusing TCP connections to gain substantial performance improvement for their apps using AWS services. I know of many developers, including myself, who had assumed that connections are reused by default and found out about the problem only when the application was struggling to cope with the number of inbound requests and when the high volume of connections was observed at the gateway through which the outbound traffic flows through (in our company setup).

I understand that the default behaviour can't be changed for compatibility reasons, therefore I'm proposing to address this issue by making the users aware of this nuance.

I would like to also give credits to the authors of these two resources that helped me better understand and then address this issue:
- https://theburningmonk.com/2019/02/lambda-optimization-tip-enable-http-keep-alive/
- https://medium.com/expedia-group-tech/under-the-hood-of-http-requests-in-node-69e27e2cd528

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
