### PR TITLE
Add --save-dev for webpack and json-loader

### DIFF
--- a/doc_source/webpack.md
+++ b/doc_source/webpack.md
@@ -13,13 +13,13 @@ For more information about webpack, see the [webpack module bundler](https://web
 To install the webpack module bundler, you must first have npm, the Node\.js package manager, installed\. Type the following command to install the webpack CLI and JavaScript module\.
 
 ```
-npm install webpack
+npm install --save-dev webpack
 ```
 
 You may also need to install a webpack plugin that allows it to load JSON files\. Type the following command to install the JSON loader plugin\.
 
 ```
-npm install json-loader
+npm install --save-dev json-loader
 ```
 
 ## Configuring Webpack<a name="webpack-configuring"></a>


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* webpack and loaders need to be present as devDependencies and not dependencies.
* Example of how it's done in aws-samples https://github.com/aws-samples/aws-sdk-js-v3-workshop/blob/93f4f77c9aa098beacc2b347a9f5508c48d6101f/Exercise1/backend/package.json#L29-L43

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
