### PR TITLE
Update the MessageId to MessageGroupId SQS NodeJS

### DIFF
--- a/doc_source/sqs-examples-send-receive-messages.md
+++ b/doc_source/sqs-examples-send-receive-messages.md
@@ -56,7 +56,7 @@ var params = {
   },
   MessageBody: "Information about current NY Times fiction bestseller for week of 12/11/2016.",
   // MessageDeduplicationId: "TheWhistler",  // Required for FIFO queues
-  // MessageId: "Group1",  // Required for FIFO queues
+  // MessageGroupId: "Group1",  // Required for FIFO queues
   QueueUrl: "SQS_QUEUE_URL"
 };
 


### PR DESCRIPTION
Update the MessageId to MessageGroupId because when send as MessageId it throws an error saying "Unexpected key 'MessageId' found in params"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
