### PR TITLE
Add the S3:PutObjectAcl in the IAM Policy

### DIFF
--- a/doc_source/s3-example-photo-album.md
+++ b/doc_source/s3-example-photo-album.md
@@ -40,6 +40,7 @@ If you enable access for unauthenticated users, you will grant write access to t
               "s3:DeleteObject",
               "s3:GetObject",
               "s3:ListBucket",
+              "s3:PutObjectAcl",
               "s3:PutObject"
            ],
            "Resource": [


### PR DESCRIPTION
Without the addition of S3:PutObjectAcl in the IAM Policy, the addPhoto function fails to update the ACL to public-read on file upload.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
