### PR TITLE
Fix "Permission Denied" errors by Adding "s3:PutObjectAcl" permission and removing slash in resource name

### DIFF
--- a/doc_source/s3-example-photo-album.md
+++ b/doc_source/s3-example-photo-album.md
@@ -40,10 +40,11 @@ If you enable access for unauthenticated users, you will grant write access to t
               "s3:DeleteObject",
               "s3:GetObject",
               "s3:ListBucket",
-              "s3:PutObject"
+              "s3:PutObject",
+              "s3:PutObjectAcl"
            ],
            "Resource": [
-              "arn:aws:s3:::BUCKET_NAME/*"
+              "arn:aws:s3:::BUCKET_NAME*"
            ]
         }
      ]


### PR DESCRIPTION
*Description of changes:*
I was getting "Permission Denied" (403) errors when trying to upload. Following [this guide](https://aws.amazon.com/premiumsupport/knowledge-center/s3-403-upload-bucket/), I've added the "S3:PutObjectAcl" permission but also had to remove the slash after the bucket name in the resource. This seems dangerous as it opens permissions to other buckets with similar names but was the only way to resolve the issues I was having. Please correct this if there's a more optimal approach.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
