### PR TITLE
comment fix

### DIFF
--- a/doc_source/s3-example-creating-buckets.md
+++ b/doc_source/s3-example-creating-buckets.md
@@ -132,7 +132,7 @@ uploadParams.Body = fileStream;
 var path = require('path');
 uploadParams.Key = path.basename(file);
 
-// call S3 to retrieve upload file to specified bucket
+// call S3 to upload file to specified bucket
 s3.upload (uploadParams, function (err, data) {
   if (err) {
     console.log("Error", err);


### PR DESCRIPTION

*Description of changes:*

Currently a comment in the documentation reads "call s3 to retrieve upload file to specified bucket".

I believe this is likely a remnant of copy-pasta used to copy-paste code snippets (including comments) from other like-documentation, and as such the word "retrieve" was unintentionally left in this comment.

The update reads, "call S3 to upload file to specified bucket"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
