### PR TITLE
Update setting-credentials-node.md

### DIFF
--- a/doc_source/setting-credentials-node.md
+++ b/doc_source/setting-credentials-node.md
@@ -2,6 +2,8 @@
 
 There are several ways in Node\.js to supply your credentials to the SDK\. Some of these are more secure and others afford greater convenience while developing an application\. When obtaining credentials in Node\.js, be careful about relying on more than one source such as an environment variable and a JSON file you load\. You can change the permissions under which your code runs without realizing the change has happened\.
 
+Some ways are synchronous and some ways are asynchronous. To ensure asynchronous credentials are available, follow the notes and examples at [AWS SDK for JavaScript > Credentials > getCredentials](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#getCredentials-property).
+
 Here are the ways you can supply your credentials in order of recommendation:
 
 1. Loaded from AWS Identity and Access Management \(IAM\) roles for Amazon EC2


### PR DESCRIPTION
*Description of changes:*
This page should clarify:

If you configure the SDK with static or environment credentials, the credential data should already be present in {credentials} attribute. However, credentials from asynchronous  sources, or sources that can refresh credentials periodically, require use of getCredentials.
(per https://github.com/aws/aws-sdk-js/blob/eb0f0ef06b50093e846bb411ed97235772bdc370/lib/config.js#L358)

I hope it saves someone else some time!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
