### PR TITLE
Add `const` when creating a new S3 service object

### DIFF
--- a/doc_source/s3-example-creating-buckets.md
+++ b/doc_source/s3-example-creating-buckets.md
@@ -44,7 +44,7 @@ var AWS = require('aws-sdk');
 AWS.config.update({region: 'REGION'});
 
 // Create S3 service object
-s3 = new AWS.S3({apiVersion: '2006-03-01'});
+const s3 = new AWS.S3({apiVersion: '2006-03-01'});
 
 // Call S3 to list the buckets
 s3.listBuckets(function(err, data) {
@@ -77,7 +77,7 @@ var AWS = require('aws-sdk');
 AWS.config.update({region: 'REGION'});
 
 // Create S3 service object
-s3 = new AWS.S3({apiVersion: '2006-03-01'});
+const s3 = new AWS.S3({apiVersion: '2006-03-01'});
 
 // Create the parameters for calling createBucket
 var bucketParams = {
@@ -115,7 +115,7 @@ var AWS = require('aws-sdk');
 AWS.config.update({region: 'REGION'});
 
 // Create S3 service object
-s3 = new AWS.S3({apiVersion: '2006-03-01'});
+const s3 = new AWS.S3({apiVersion: '2006-03-01'});
 
 // call S3 to retrieve upload file to specified bucket
 var uploadParams = {Bucket: process.argv[2], Key: '', Body: ''};
@@ -162,7 +162,7 @@ var AWS = require('aws-sdk');
 AWS.config.update({region: 'REGION'});
 
 // Create S3 service object
-s3 = new AWS.S3({apiVersion: '2006-03-01'});
+const s3 = new AWS.S3({apiVersion: '2006-03-01'});
 
 // Create the parameters for calling listObjects
 var bucketParams = {
@@ -200,7 +200,7 @@ var AWS = require('aws-sdk');
 AWS.config.update({region: 'REGION'});
 
 // Create S3 service object
-s3 = new AWS.S3({apiVersion: '2006-03-01'});
+const s3 = new AWS.S3({apiVersion: '2006-03-01'});
 
 // Create params for S3.deleteBucket
 var bucketParams = {


### PR DESCRIPTION
*Issue #, if available:* (no issue number)


*Description of changes:*
I tried using the sample code on this documentation, but it kept saying `ReferenceError: s3 is not defined`. I had to add `const` before `s3 = new AWS.S3({ apiVersion: "2006-03-01" });` to fix it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
