### PR TITLE
Update ses-examples-sending-email.md

### DIFF
--- a/doc_source/ses-examples-sending-email.md
+++ b/doc_source/ses-examples-sending-email.md
@@ -59,7 +59,7 @@ var params = {
       /* more items */
     ]
   },
-  Message: { /* required */
+  Content: { /* required */
     Body: { /* required */
       Html: {
        Charset: "UTF-8",


### PR DESCRIPTION
SendEmailCommandInput (which extends interface SendEmailRequest) no longer supports 'Message', it should be 'Content'

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
